### PR TITLE
Adding TMC CLI to the helper image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ kp
 kapp
 ytt
 pivnet
+tmc
 local-config/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,6 @@ COPY kp /usr/bin/kp
 COPY kubectl /usr/bin/kubectl
 COPY kapp /usr/bin/kapp
 COPY ytt /usr/bin/ytt
+COPY tmc /usr/bin/tmc
 
 ENTRYPOINT [ "echo hello" ]

--- a/Readme.md
+++ b/Readme.md
@@ -6,6 +6,7 @@ Provides image for concourse tasks that have the following utilities:
 - ytt
 - kubectl
 - kp
+- tmc
 
 ## Prerequisites before building image 
 

--- a/retrieve-utilities.sh
+++ b/retrieve-utilities.sh
@@ -1,3 +1,5 @@
+#! /usr/bin/env bash
+
 rm kubectl
 curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.19.1/bin/linux/amd64/kubectl
 chmod +x ./kubectl
@@ -25,3 +27,7 @@ rm kp
   --config=$PIVNET_CONFIG
  chmod +x ./kp-linux-0.1.3
  mv kp-linux-0.1.3 kp
+
+rm tmc
+curl -LO https://tmc-cli.s3-us-west-2.amazonaws.com/tmc/0.2.0-ba47223d/linux/x64/tmc
+chmod +x ./tmc


### PR DESCRIPTION
Add TMC CLI in case user is trying to use a TMC provisioned TKG cluster.